### PR TITLE
Adding Factors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ being in the crawler. For 9gag you can add any site that hits the scheme `http:/
 
 Crawlers can be weighted against each other with optional factors ranging from 0.1 to 10.0:  
 ```
-SoupIO: everyone-2.5
-Pr0gramm: static-5.0, new-0.5, top
+SoupIO: everyone*2.5
+Pr0gramm: static*5.0, new*0.5, top
 ```
 
 The default factor is 1.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Giphy: feels, alcohol, fail, troll, diy, robot, stars, physics
 For example Reddit: wtf,gifs will end up in `http://reddit.com/r/wtf` and `http://reddit.com/r/gifs` end up
 being in the crawler. For 9gag you can add any site that hits the scheme `http://9gag.com/<topic>`.
 
+Crawlers can be weighted against each other with optional factors ranging from 0.1 to 10.0:  
+```
+SoupIO: everyone-2.5
+Pr0gramm: static-5.0, new-0.5, top
+```
+
+The default factor is 1.
+In the configuration above the images from SoupIO-everyone should be around the half of Pr0gramm-static as well as around five times as much as Pr0gramm-new.
 
 ## contribution
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (K
 
 ### cache
 
-`Images` indicates how many images will be loaded on each crawler run
+`Images` indicates how many images will be loaded per crawler on each crawler run
 `Images_min_limit` configures at how many images the crawler starts again collecting new images from the sites.
 
 ```
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 ```
 
 ### logging
@@ -135,7 +135,7 @@ below.
 
 when you start nichtparasoup
 
-* fill up cache by startup (150 imageurls cached by default)
+* fill up cache by startup (30 imageurls cached per defined crawler by default)
 * starts up the webserver
 * point your browser to the configured `localhost:5000/`
 * startpage will request single image randomly by `/get` and show them

--- a/config.defaults.ini
+++ b/config.defaults.ini
@@ -12,8 +12,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/config.ini
+++ b/config.ini
@@ -6,8 +6,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -317,7 +317,8 @@ class Crawler(object):
 
         info = {
             "blacklist": len(blacklist),
-            "blacklist_size": sys.getsizeof(blacklist, 0)
+            "blacklist_size": sys.getsizeof(blacklist, 0),
+            "images_per_site": {}
         }
 
         images_count = 0
@@ -327,7 +328,7 @@ class Crawler(object):
                 site_image_count = len(images[crawler][site])
                 images_count += site_image_count
                 images_size += sys.getsizeof(images[crawler][site])
-                info[crawler + "_" + site] = site_image_count
+                info["images_per_site"][crawler + "_" + site] = site_image_count
 
         info["images_size"] = images_size
         info["images"] = images_count

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -247,50 +247,34 @@ class Crawler(object):
         images = cls.__images
         factors = cls.__factors
         if images:
+            # return image respecting factors:
+            # Summing up the Factors till reaching a random number
 
-            if not factors:
-                # Without factors, return random image from Cache
-                image_found = False
-                while not image_found:
-                    crawler = random.choice(images.keys())
-                    site = random.choice(images[crawler].keys())
-                    image_found = len(images[crawler][site]) > 0
+            max = 0
+            for crawler in images:
+                for site in images[crawler]:
+                    factor = 1
+                    if crawler in factors and site in factors[crawler]:
+                        factor = factors[crawler][site]
 
-                image = random.choice(images[crawler][site])
-                images[crawler][site].remove(image)
-                cls._log("debug", "delivered %s-%s: %s - remaining: %d"
-                         % (crawler, site, image, len(images[crawler][site])))
-                return image
+                    max += factor
 
-            else:
-                # return image respecting factors:
-                # Summing up the Factors till reaching a random number
+            rnd = random.uniform(0, max)
 
-                max = 0
-                for crawler in images:
-                    for site in images[crawler]:
-                        factor = 1
-                        if crawler in factors and site in factors[crawler]:
-                            factor = factors[crawler][site]
+            count = 0
+            for crawler in images:
+                for site in images[crawler]:
+                    factor = 1
+                    if crawler in factors and site in factors[crawler]:
+                        factor = factors[crawler][site]
 
-                        max += factor
-
-                rnd = random.uniform(0, max)
-
-                count = 0
-                for crawler in images:
-                    for site in images[crawler]:
-                        factor = 1
-                        if crawler in factors and site in factors[crawler]:
-                            factor = factors[crawler][site]
-
-                        count += factor
-                        if count > rnd:
-                            image = random.choice(images[crawler][site])
-                            images[crawler][site].remove(image)
-                            cls._log("debug", "delivered %s-%s: %s - remaining: %d"
-                                     % (crawler, site, image, len(images[crawler][site])))
-                            return image
+                    count += factor
+                    if count > rnd:
+                        image = random.choice(images[crawler][site])
+                        images[crawler][site].remove(image)
+                        cls._log("debug", "delivered %s-%s: %s - remaining: %d"
+                                 % (crawler, site, image, len(images[crawler][site])))
+                        return image
         return None
 
     @classmethod

--- a/crawler/__init__.py
+++ b/crawler/__init__.py
@@ -277,18 +277,20 @@ class Crawler(object):
         blacklist = cls.__blacklist
 
         info = {
-            "images_size": sys.getsizeof(images, 0),
             "blacklist": len(blacklist),
             "blacklist_size": sys.getsizeof(blacklist, 0)
         }
 
         images_count = 0
+        images_size = 0
         for crawler in images:
             for site in images[crawler]:
                 site_image_count = len(images[crawler][site])
                 images_count += site_image_count
+                images_size += sys.getsizeof(images[crawler][site])
                 info[crawler + "_" + site] = site_image_count
 
+        info["images_size"] = images_size
         info["images"] = images_count
 
         return info

--- a/crawler/fourchan.py
+++ b/crawler/fourchan.py
@@ -48,7 +48,7 @@ class Fourchan(Crawler):
 
         images_added = 0
         for con in page.find_all("a", {"class": "fileThumb", "href": True}):
-            if self._add_image(urljoin(base, con["href"])):
+            if self._add_image(urljoin(base, con["href"]), self.__site):
                 images_added += 1
 
         if not images_added:

--- a/crawler/fourchan.py
+++ b/crawler/fourchan.py
@@ -14,6 +14,7 @@ class Fourchan(Crawler):
 
     __uri = ""
     __next = ""
+    __site = ""
 
     @staticmethod
     def __build_uri(uri):
@@ -22,7 +23,8 @@ class Fourchan(Crawler):
     def _restart_at_front(self):
         self.__next = self.__uri
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/giphy.py
+++ b/crawler/giphy.py
@@ -45,7 +45,7 @@ class Giphy(Crawler):
         for child in data['data']:
             image = child['images']['original']['url']
             if image:
-                if self._add_image(image):
+                if self._add_image(image, self.__site):
                     images_added += 1
 
         if not images_added:

--- a/crawler/giphy.py
+++ b/crawler/giphy.py
@@ -10,6 +10,7 @@ class Giphy(Crawler):
 
     __uri = ""
     __next = 0
+    __site = ""
 
     __limit = 50
 
@@ -22,7 +23,8 @@ class Giphy(Crawler):
     def _restart_at_front(self):
         self.__next = 0
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__._build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/instagram.py
+++ b/crawler/instagram.py
@@ -57,7 +57,7 @@ class Instagram(Crawler):
                     and 'url' in item_image['images']['standard_resolution']:
                 image = item_image['images']['standard_resolution']['url']
                 if image:
-                    if self._add_image(image):
+                    if self._add_image(image, self.__site):
                         images_added += 1
 
         if not images_added:

--- a/crawler/instagram.py
+++ b/crawler/instagram.py
@@ -16,6 +16,7 @@ class Instagram(Crawler):
 
     __uri = ""
     __last = ""
+    __site = ""
 
     ## class methods
 
@@ -28,7 +29,8 @@ class Instagram(Crawler):
     def _restart_at_front(self):
         self.__last = ""
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/ninegag.py
+++ b/crawler/ninegag.py
@@ -71,7 +71,7 @@ class NineGag(Crawler):
                 image = image_src['src']
 
             if image:
-                if self._add_image(urljoin(base, image)):
+                if self._add_image(urljoin(base, image), self.__site):
                     images_added += 1
 
         if not images_added:

--- a/crawler/ninegag.py
+++ b/crawler/ninegag.py
@@ -16,6 +16,7 @@ class NineGag(Crawler):
 
     __uri = ""
     __next = ""
+    __site = ""
 
     __RE_post_container = re.compile("badge-post-container")
 
@@ -26,7 +27,8 @@ class NineGag(Crawler):
     def _restart_at_front(self):
         self.__next = self.__uri
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/pr0gramm.py
+++ b/crawler/pr0gramm.py
@@ -66,4 +66,4 @@ class Pr0gramm(Crawler):
         if not image:
             return False
 
-        return self._add_image(urljoin(base, image["src"]))
+        return self._add_image(urljoin(base, image["src"]), self.__site)

--- a/crawler/pr0gramm.py
+++ b/crawler/pr0gramm.py
@@ -18,6 +18,7 @@ class Pr0gramm(Crawler):
 
     __uri = ""
     __next = ""
+    __site = ""
 
     __filter = re.compile('^/static/[\d]+')
 
@@ -30,7 +31,8 @@ class Pr0gramm(Crawler):
     def _restart_at_front(self):
         self.__next = self.__uri
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/reddit.py
+++ b/crawler/reddit.py
@@ -15,6 +15,7 @@ class Reddit(Crawler):
 
     __uri = ""
     __next = ""
+    __site = ""
 
     @staticmethod
     def __build_uri(uri):
@@ -23,7 +24,8 @@ class Reddit(Crawler):
     def _restart_at_front(self):
         self.__next = ""
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/crawler/reddit.py
+++ b/crawler/reddit.py
@@ -46,7 +46,7 @@ class Reddit(Crawler):
         for child in data['data']['children']:
             image = child['data']['url']
             if image:
-                if self._add_image(image):
+                if self._add_image(image, self.__site):
                     images_added += 1
 
         if not images_added:

--- a/crawler/soupio.py
+++ b/crawler/soupio.py
@@ -56,7 +56,7 @@ class SoupIO(Crawler):
         for con in page.find_all("div", {"class": "imagecontainer"}):
             image = con.find('img', {"src": True})
             if image:
-                if self._add_image(urljoin(base, image['src'])):
+                if self._add_image(urljoin(base, image['src']), self.__site):
                     images_added += 1
 
         if not images_added:

--- a/crawler/soupio.py
+++ b/crawler/soupio.py
@@ -13,6 +13,7 @@ class SoupIO(Crawler):
 
     __uri = ""
     __next = ""
+    __site = ""
 
     @staticmethod
     def __build_uri(uri):
@@ -21,7 +22,8 @@ class SoupIO(Crawler):
     def _restart_at_front(self):
         self.__next = self.__uri
 
-    def __init__(self, uri):
+    def __init__(self, uri, site):
+        self.__site = site
         self.__uri = self.__class__.__build_uri(uri)
         self._restart_at_front()
 

--- a/kadsen.ini
+++ b/kadsen.ini
@@ -6,8 +6,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/nichtparasoup.py
+++ b/nichtparasoup.py
@@ -197,7 +197,6 @@ def cache_status():
     logger.info(msg)
     return msg
 
-
 # print imagelist
 def show_imagelist():
     return "\n".join(Crawler.show_imagelist())

--- a/nichtparasoup.py
+++ b/nichtparasoup.py
@@ -186,8 +186,9 @@ def cache_fill_loop():
         for crawler in sources:
             for site in sources[crawler]:
                 key = crawler + "_" + site
-                if key not in info or info[key] < min_cache_imgs_before_refill:
-                    while key not in info or info[key] < min_cache_imgs:
+
+                if key not in info or info["images_per_site"][key] < min_cache_imgs_before_refill:
+                    while key not in info or info["images_per_site"][key] < min_cache_imgs:
                         sources[crawler][site].crawl()
                         info = Crawler.info()
 
@@ -210,13 +211,13 @@ def cache_status():
     for crawler in sources:
         for site in sources[crawler]:
             key = crawler + "_" + site
-            if key in info:
+            if key in info["images_per_site"]:
 
                 factor = 1
                 if crawler in factors and site in factors[crawler]:
                     factor = factors[crawler][site]
 
-                count = info[key]
+                count = info["images_per_site"][key]
 
                 # "Drawing" a Bar to visualize the cache status
                 sharps_percent = min_cache_imgs_before_refill * 100 / min_cache_imgs

--- a/nichtparasoup.py
+++ b/nichtparasoup.py
@@ -187,8 +187,8 @@ def cache_fill_loop():
             for site in sources[crawler]:
                 key = crawler + "_" + site
 
-                if key not in info or info["images_per_site"][key] < min_cache_imgs_before_refill:
-                    while key not in info or info["images_per_site"][key] < min_cache_imgs:
+                if key not in info["images_per_site"] or info["images_per_site"][key] < min_cache_imgs_before_refill:
+                    while key not in info["images_per_site"] or info["images_per_site"][key] < min_cache_imgs:
                         sources[crawler][site].crawl()
                         info = Crawler.info()
 

--- a/nichtparasoup.py
+++ b/nichtparasoup.py
@@ -61,7 +61,7 @@ hdlr.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
 logger.addHandler(hdlr)
 logger.setLevel(logverbosity.upper())
 
-factor_separator = "-"
+factor_separator = "*"
 call_flush_timeout = 10  # value in seconds
 call_flush_last = time.time() - call_flush_timeout
 
@@ -112,8 +112,7 @@ def get_crawlers(configuration, section):
             elif crawler_class == SoupIO:
                 crawler_config = "everyone"
 
-        crawler_sites_and_factors = [url_quote_plus(site_stripped) for site_stripped in
-                                     [site.strip() for site in crawler_config.split(",")]  # trim sites
+        crawler_sites_and_factors = [site_stripped for site_stripped in [site.strip() for site in crawler_config.split(",")]  # trim sites
                                      if site_stripped]  # filter stripped list for valid values
 
         if not crawler_sites_and_factors:
@@ -126,7 +125,7 @@ def get_crawlers(configuration, section):
         for factorPair in crawler_sites_and_factors:
             if factor_separator not in factorPair:
                 # No Factor configured
-                crawler_sites.append(factorPair)
+                crawler_sites.append(url_quote_plus(factorPair))
                 continue
 
             factorPair_parts = [factorPairPart.strip() for factorPairPart in factorPair.split(factor_separator)]
@@ -134,7 +133,7 @@ def get_crawlers(configuration, section):
             if not factorPair_parts or not len(factorPair_parts) == 2:
                 continue
 
-            site = factorPair_parts[0]
+            site = url_quote_plus(factorPair_parts[0])
             factor = float(factorPair_parts[1])
 
             crawler_sites.append(site)
@@ -238,8 +237,6 @@ def cache_status():
                 sitestats = ("%15s - %-15s with factor %4.1f: %2d Images " + bar) % (crawler, site, factor, count)
                 logger.info(sitestats)
                 msg += "\r\n" + sitestats
-
-    logger.info(msg)
     return msg
 
 # print imagelist

--- a/nichtparasoup.py
+++ b/nichtparasoup.py
@@ -173,6 +173,8 @@ def get_crawlers(configuration, section):
 (sources, factors) = get_crawlers(config, "Sites")
 if not sources:
     raise Exception("no sources configured")
+if factors:
+    Crawler.set_factors(factors)
 
 
 # wrapper function for cache filling
@@ -214,7 +216,25 @@ def cache_status():
                 if crawler in factors and site in factors[crawler]:
                     factor = factors[crawler][site]
 
-                sitestats = "%15s - %-15s with factor %2d: %d Images" % (crawler, site, factor, info[key])
+                count = info[key]
+
+                # "Drawing" a Bar to visualize the cache status
+                sharps_percent = min_cache_imgs_before_refill * 100 / min_cache_imgs
+                count_percent = count * 100 / min_cache_imgs
+
+                bar = "["
+                for i in range(1,15):
+                    if i * 10 < count_percent:
+                        if i * 10 < sharps_percent:
+                            bar += "#"
+                        else:
+                            bar += "*"
+                    elif i <= 10:
+                        bar += "_"
+                    if i == 10:
+                        bar += "]"
+
+                sitestats = ("%15s - %-15s with factor %4.1f: %2d Images " + bar) % (crawler, site, factor, count)
                 logger.info(sitestats)
                 msg += "\r\n" + sitestats
 

--- a/nsfw.ini
+++ b/nsfw.ini
@@ -6,8 +6,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/pr0.ini
+++ b/pr0.ini
@@ -6,8 +6,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/sfw.ini
+++ b/sfw.ini
@@ -6,8 +6,8 @@ IP: 0.0.0.0
 Useragent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/600.1.25 (KHTML, like Gecko) Version/8.0 Safari/600.1.25
 
 [Cache]
-Images: 150
-Images_min_limit: 20
+Images: 30
+Images_min_limit: 15
 
 [Logging]
 Log_name: nichtparasoup

--- a/tests/configs/factors.ini
+++ b/tests/configs/factors.ini
@@ -1,0 +1,10 @@
+; congig for nichtparasoup - Reddit crawler
+
+[Logging]
+Log_name: nichtparasoup_test_factors
+File: tests/logs/factors.log
+Verbosity: DEBUG
+
+[Sites]
+Reddit:cats-2.0
+Pr0gramm:top

--- a/tests/configs/factors.ini
+++ b/tests/configs/factors.ini
@@ -1,4 +1,4 @@
-; congig for nichtparasoup - Reddit crawler
+; congig for nichtparasoup
 
 [Logging]
 Log_name: nichtparasoup_test_factors
@@ -6,7 +6,7 @@ File: tests/logs/factors.log
 Verbosity: DEBUG
 
 [Sites]
-Reddit:cats-0.1
-Pr0gramm:top-0.1
-Fourchan: vr-0.1
-Reddit: nsfw-0.1,gifs-0.1,pics-0.1,nsfw_gifs-0.1,aww-0.1,aww_gifs-0.1,reactiongifs-0.1,wtf-0.1,FoodPorn-0.1,cats-0.1,StarWars-10.0
+Reddit:cats*0.1
+Pr0gramm:top*0.1
+Fourchan: vr*0.1
+Reddit: nsfw*0.1,gifs*0.1,pics*0.1,nsfw_gifs*0.1,aww*0.1,aww_gifs*0.1,reactiongifs*0.1,wtf*0.1,FoodPorn*0.1,cats*0.1,StarWars*10.0

--- a/tests/configs/factors.ini
+++ b/tests/configs/factors.ini
@@ -6,5 +6,7 @@ File: tests/logs/factors.log
 Verbosity: DEBUG
 
 [Sites]
-Reddit:cats-2.0
-Pr0gramm:top
+Reddit:cats-0.1
+Pr0gramm:top-0.1
+Fourchan: vr-0.1
+Reddit: nsfw-0.1,gifs-0.1,pics-0.1,nsfw_gifs-0.1,aww-0.1,aww_gifs-0.1,reactiongifs-0.1,wtf-0.1,FoodPorn-0.1,cats-0.1,StarWars-10.0


### PR DESCRIPTION
After the changes the distribution of images delivered by GET are distributed evenly among the crawler sites. This can further be configured by a factor per site between 0.1 and 10, the default value is 1:
```
SoupIO: everyone*2.5
Pr0gramm: static*5.0, new*0.5, top
```
For that to be possible, the crawling had to be changed from crawling to a fixed image count over all crawlers to crawling to a fixed image count per crawler site, as seen in /status:
```
images cached: 185 (2128 bytes) - already crawled: 185 (1680 bytes)
         Reddit - gifs            with factor  1.0: 32 Images [####******]
         Reddit - StarWars        with factor  1.0: 34 Images [####******]*
         Reddit - aww             with factor  1.0: 39 Images [####******]**
         Reddit - FoodPorn        with factor  1.0: 38 Images [####******]**
         Reddit - reactiongifs    with factor  1.0: 38 Images [####******]**
         Reddit - aww_gifs        with factor  1.0:  4 Images [#_________]
```
In the "bar" at the end one character symbols 10% in the cache, the sharps are the part of the cache where crawling is started:
```
[##________]      20% of Cache is filled, crawling will start soon
[####**____]      60% of Cache filled, no crawling expected
[####******]***   130% of Cache filled, crawler added more images then needed
```
