### PR TITLE
Webserver Rule '/' redirects to Webroot

### DIFF
--- a/nichtparasoup/webserver/__init__.py
+++ b/nichtparasoup/webserver/__init__.py
@@ -20,7 +20,7 @@ class WebServer(object):
         self.hostname = hostname
         self.port = port
         self.url_map = Map([
-            Rule("/", redirect_to="/index.html"),
+            Rule("/", redirect_to="./index.html"),
             Rule('/get', endpoint='get'),
             Rule('/status', endpoint='status'),
             Rule('/status/<what>', endpoint='status_what'),


### PR DESCRIPTION
When I have nichtparasoup running in a subdirectory, like 

nicht.parasoup.de/sfw/

I'm getting redirected to 

nicht.parasoup.de/index.html 

The suggested change should fix this behaviour