### PR TITLE
Fix function method caching

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -94,6 +94,10 @@ see the [milestone tracking at github](https://github.com/k4cg/nichtparasoup/mil
     * Method `.__str__()` .  
       Returns `<NamedImagecrawler {INTERNAL_NAME} {CONFIG!r}>` if `internal_name` is set, 
       otherwise the behaviour falls back to `__repr__()`.
+  * Public stuff in module `nichtparasoup.imagecrawers.instagram` (was nonpublic before):
+    * Class `.BaseInstagramCrawler` became public. (since it does `Lock()` allocation automatically, now.)
+    * Class `.InstagramQueryHashFinder` became public for extending `.BaseInstagramCrawler`.
+    * Constants `.INSTAGRAM_URL_ROOT` and `.INSTAGRAM_ICON_URL` became public for extending `.BaseInstagramCrawler`.
 * Misc
   * Build process is now isolated and conform to
     [PEP517](https://www.python.org/dev/peps/pep-0517/) &

--- a/src/nichtparasoup/imagecrawlers/__init__.py
+++ b/src/nichtparasoup/imagecrawlers/__init__.py
@@ -1,7 +1,8 @@
 __all__ = [
-    "get_imagecrawlers",
+    "get_imagecrawlers", "clear_imagecrawlers",
 ]
 
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
 
 from pkg_resources import EntryPoint, iter_entry_points
@@ -116,16 +117,18 @@ class KnownImageCrawlers:
 
 __ENTRY_POINT_NAME = 'nichtparasoup_imagecrawler'
 
-__imagecrawlers: Optional[KnownImageCrawlers] = None
 
-
+@lru_cache(maxsize=1)
 def get_imagecrawlers() -> KnownImageCrawlers:  # pragma: no cover
-    global __imagecrawlers
-    if __imagecrawlers is None:
-        __imagecrawlers = KnownImageCrawlers(iter_entry_points(__ENTRY_POINT_NAME))
-    return __imagecrawlers
+    """Get :ref:``KnownImageCrawlers``.
+
+    Uses caching.
+    To clear the cache use :ref:``clear_imagecrawlers()``.
+    """
+    return KnownImageCrawlers(iter_entry_points(__ENTRY_POINT_NAME))
 
 
 def clear_imagecrawlers() -> None:  # pragma: no cover
-    global __imagecrawlers
-    __imagecrawlers = None
+    """Clear the cache of :ref:``get_imagecrawlers``
+    """
+    get_imagecrawlers.cache_clear()


### PR DESCRIPTION
* improve function caching of `nichtparasoup.imagecrwlers.get_imagecrawlers()`
* improved `nichtparasoup.imagecrawlers.instagram.BaseInstagramCrawler`'s query hash caching for subclasses.
* made `nichtparasoup.imagecrawlers.instagram.BaseInstagramCrawler` public
