### PR TITLE
bumped isort, bumped flake8-isort, removed pylint

### DIFF
--- a/python-package/requirements/dev.in
+++ b/python-package/requirements/dev.in
@@ -2,5 +2,5 @@
 -r tests.in
 -r tox.in
 pip-tools >= 5.3
-isort >= 4.3
+isort >= 5.0
 autopep8 >= 1.5

--- a/python-package/requirements/dev.txt
+++ b/python-package/requirements/dev.txt
@@ -6,48 +6,47 @@
 #
 apipkg==1.5               # via execnet
 appdirs==1.4.4            # via virtualenv
-astroid==2.4.2            # via pylint
 attrs==19.3.0             # via flake8-bugbear, pytest
-autopep8==1.5.4           # via -r requirements/dev.in
+autopep8==1.5.4           # via -r ./dev.in
 click==7.1.2              # via pip-tools
-coverage==5.2.1           # via -r requirements/tests.in, pytest-cov
+coverage==5.2.1           # via -r ./tests.in, pytest-cov
 distlib==0.3.1            # via virtualenv
 execnet==1.7.1            # via pytest-xdist
 filelock==3.0.12          # via tox, virtualenv
-flake8-annotations==2.3.0  # via -r requirements/style.in
-flake8-bugbear==20.1.4    # via -r requirements/style.in
-flake8-isort==3.0.1       # via -r requirements/style.in
+flake8-annotations==2.3.0  # via -r ./style.in
+flake8-bugbear==20.1.4    # via -r ./style.in
+flake8-isort==4.0.0       # via -r ./style.in
 flake8-polyfill==1.0.2    # via pep8-naming
-flake8-use-fstring==1.1   # via -r requirements/style.in
-flake8==3.8.3             # via -r requirements/style.in, flake8-annotations, flake8-bugbear, flake8-isort, flake8-polyfill, flake8-use-fstring
+flake8-use-fstring==1.1   # via -r ./style.in
+flake8==3.8.3             # via -r ./style.in, flake8-annotations, flake8-bugbear, flake8-isort, flake8-polyfill, flake8-use-fstring
+importlib-metadata==1.7.0  # via flake8, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 iniconfig==1.0.1          # via pytest
-isort[pyproject]==4.3.21  # via -r requirements/dev.in, flake8-isort, pylint
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via flake8, pylint
+isort==5.3.2              # via -r ./dev.in, flake8-isort
+mccabe==0.6.1             # via flake8
 more-itertools==8.4.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
-mypy==0.782               # via -r requirements/style.in
+mypy==0.782               # via -r ./style.in
 packaging==20.4           # via pytest, tox
-pep8-naming==0.11.1       # via -r requirements/style.in
-pip-tools==5.3.1          # via -r requirements/dev.in
+pep8-naming==0.11.1       # via -r ./style.in
+pip-tools==5.3.1          # via -r ./dev.in
 pluggy==0.13.1            # via pytest, tox
 py==1.9.0                 # via pytest, pytest-forked, tox
 pycodestyle==2.6.0        # via autopep8, flake8
 pyflakes==2.2.0           # via flake8
-pylint==2.5.3             # via -r requirements/style.in
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/tests.in
+pytest-cov==2.10.0        # via -r ./tests.in
 pytest-forked==1.3.0      # via pytest-xdist
-pytest-xdist==1.34.0      # via -r requirements/tests.in
-pytest==6.0.1             # via -r requirements/tests.in, pytest-cov, pytest-forked, pytest-xdist
-six==1.15.0               # via astroid, packaging, pip-tools, pytest-xdist, tox, virtualenv
+pytest-xdist==1.34.0      # via -r ./tests.in
+pytest==6.0.1             # via -r ./tests.in, pytest-cov, pytest-forked, pytest-xdist
+six==1.15.0               # via packaging, pip-tools, pytest-xdist, tox, virtualenv
 testfixtures==6.14.1      # via flake8-isort
-toml==0.10.1              # via autopep8, isort, pylint, pytest, tox
-tox==3.19.0               # via -r requirements/tox.in
-typed-ast==1.4.1          # via mypy
+toml==0.10.1              # via autopep8, pytest, tox
+tox==3.19.0               # via -r ./tox.in
+typed-ast==1.4.1          # via flake8-annotations, mypy
 typing-extensions==3.7.4.2  # via mypy
 virtualenv==20.0.30       # via tox
-wrapt==1.12.1             # via astroid
+zipp==3.1.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/python-package/requirements/style.in
+++ b/python-package/requirements/style.in
@@ -1,7 +1,7 @@
 flake8 >= 3.7
 flake8-annotations >= 2.0
 flake8-bugbear >= 20.1
-flake8-isort >= 2.8
+flake8-isort >= 4.0
 flake8-use-fstring >= 1.1
 pep8-naming >= 0.9
 # flake8-builtins  # nice in general, but seams not bug-free, yet.
@@ -10,4 +10,4 @@ pep8-naming >= 0.9
 
 mypy >= 0.761
 
-pylint >= 2.5
+# pylint >= 2.5

--- a/python-package/requirements/style.txt
+++ b/python-package/requirements/style.txt
@@ -4,28 +4,22 @@
 #
 #    pip-compile ./style.in
 #
-astroid==2.4.2            # via pylint
 attrs==19.3.0             # via flake8-bugbear
 flake8-annotations==2.3.0  # via -r ./style.in
 flake8-bugbear==20.1.4    # via -r ./style.in
-flake8-isort==3.0.1       # via -r ./style.in
+flake8-isort==4.0.0       # via -r ./style.in
 flake8-polyfill==1.0.2    # via pep8-naming
 flake8-use-fstring==1.1   # via -r ./style.in
 flake8==3.8.3             # via -r ./style.in, flake8-annotations, flake8-bugbear, flake8-isort, flake8-polyfill, flake8-use-fstring
 importlib-metadata==1.7.0  # via flake8
-isort[pyproject]==4.3.21  # via flake8-isort, pylint
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via flake8, pylint
+isort==5.3.2              # via flake8-isort
+mccabe==0.6.1             # via flake8
 mypy-extensions==0.4.3    # via mypy
 mypy==0.782               # via -r ./style.in
 pep8-naming==0.11.1       # via -r ./style.in
 pycodestyle==2.6.0        # via flake8
 pyflakes==2.2.0           # via flake8
-pylint==2.5.3             # via -r ./style.in
-six==1.15.0               # via astroid
 testfixtures==6.14.1      # via flake8-isort
-toml==0.10.1              # via isort, pylint
-typed-ast==1.4.1          # via astroid, flake8-annotations, mypy
+typed-ast==1.4.1          # via flake8-annotations, mypy
 typing-extensions==3.7.4.2  # via mypy
-wrapt==1.12.1             # via astroid
 zipp==3.1.0               # via importlib-metadata

--- a/python-package/requirements/tox.txt
+++ b/python-package/requirements/tox.txt
@@ -7,11 +7,14 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.19.0               # via -r requirements/tox.in
+tox==3.19.0               # via -r ./tox.in
 virtualenv==20.0.30       # via tox
+zipp==3.1.0               # via importlib-metadata, importlib-resources

--- a/python-package/src/nichtparasoup/_internals.py
+++ b/python-package/src/nichtparasoup/_internals.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, List, Optional, TextIO, Type, Union
 
 if sys.version_info >= (3, 8):
-    from typing import Literal   # pylint: disable=no-name-in-module
+    from typing import Literal  # pylint: disable=no-name-in-module
 else:
     from typing_extensions import Literal
 

--- a/python-plugin-example/.isort.cfg
+++ b/python-plugin-example/.isort.cfg
@@ -8,6 +8,6 @@ skip_glob =
 combine_as_imports = true
 default_section = THIRDPARTY
 include_trailing_comma = true
-known_first_party = nichtparasoup
+known_first_party = nichtparasoup_imagecrawler_dummyimage
 line_length = 120
 multi_line_output = 5

--- a/python-plugin-example/requirements/dev.in
+++ b/python-plugin-example/requirements/dev.in
@@ -2,3 +2,5 @@
 -r tests.in
 -r tox.in
 pip-tools >= 5.3
+isort >= 5.0
+autopep8 >= 1.5

--- a/python-plugin-example/requirements/dev.txt
+++ b/python-plugin-example/requirements/dev.txt
@@ -5,34 +5,34 @@
 #    pip-compile ./dev.in
 #
 appdirs==1.4.4            # via virtualenv
-astroid==2.4.2            # via pylint
 attrs==19.3.0             # via pytest
+autopep8==1.5.4           # via -r ./dev.in
 click==7.1.2              # via pip-tools
-coverage==5.2.1           # via -r requirements/tests.in, pytest-cov
+coverage==5.2.1           # via -r ./tests.in, pytest-cov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 iniconfig==1.0.1          # via pytest
-isort==4.3.21             # via pylint
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via pylint
+isort==5.3.2              # via -r ./dev.in
 more-itertools==8.4.0     # via pytest
 mypy-extensions==0.4.3    # via mypy
-mypy==0.782               # via -r requirements/style.in
+mypy==0.782               # via -r ./style.in
 packaging==20.4           # via pytest, tox
-pip-tools==5.3.1          # via -r requirements/dev.in
+pip-tools==5.3.1          # via -r ./dev.in
 pluggy==0.13.1            # via pytest, tox
 py==1.9.0                 # via pytest, tox
-pylint==2.5.3             # via -r requirements/style.in
+pycodestyle==2.6.0        # via autopep8
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.10.0        # via -r requirements/tests.in
-pytest==6.0.1             # via -r requirements/tests.in, pytest-cov
-six==1.15.0               # via astroid, packaging, pip-tools, tox, virtualenv
-toml==0.10.1              # via pylint, pytest, tox
-tox==3.19.0               # via -r requirements/tox.in
+pytest-cov==2.10.0        # via -r ./tests.in
+pytest==6.0.1             # via -r ./tests.in, pytest-cov
+six==1.15.0               # via packaging, pip-tools, tox, virtualenv
+toml==0.10.1              # via autopep8, pytest, tox
+tox==3.19.0               # via -r ./tox.in
 typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.2  # via mypy
 virtualenv==20.0.30       # via tox
-wrapt==1.12.1             # via astroid
+zipp==3.1.0               # via importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/python-plugin-example/requirements/style.in
+++ b/python-plugin-example/requirements/style.in
@@ -1,3 +1,3 @@
 mypy >= 0.761
 
-pylint >= 2.5
+# pylint >= 2.5

--- a/python-plugin-example/requirements/style.txt
+++ b/python-plugin-example/requirements/style.txt
@@ -4,15 +4,7 @@
 #
 #    pip-compile ./style.in
 #
-astroid==2.4.2            # via pylint
-isort==4.3.21             # via pylint
-lazy-object-proxy==1.4.3  # via astroid
-mccabe==0.6.1             # via pylint
 mypy-extensions==0.4.3    # via mypy
 mypy==0.782               # via -r ./style.in
-pylint==2.5.3             # via -r ./style.in
-six==1.15.0               # via astroid
-toml==0.10.1              # via pylint
-typed-ast==1.4.1          # via astroid, mypy
+typed-ast==1.4.1          # via mypy
 typing-extensions==3.7.4.2  # via mypy
-wrapt==1.12.1             # via astroid

--- a/python-plugin-example/requirements/tox.txt
+++ b/python-plugin-example/requirements/tox.txt
@@ -7,11 +7,14 @@
 appdirs==1.4.4            # via virtualenv
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.19.0               # via -r requirements/tox.in
+tox==3.19.0               # via -r ./tox.in
 virtualenv==20.0.30       # via tox
+zipp==3.1.0               # via importlib-metadata, importlib-resources

--- a/python-plugin-example/tests/test_10_nichtparasoup_placeholders/test_dummyimage.py
+++ b/python-plugin-example/tests/test_10_nichtparasoup_placeholders/test_dummyimage.py
@@ -2,9 +2,9 @@ import unittest
 from typing import Any, List
 
 import pytest
-from nichtparasoup_imagecrawler_dummyimage import DummyImage
-
 from nichtparasoup.testing.imagecrawler import ImageCrawlerLoaderTest
+
+from nichtparasoup_imagecrawler_dummyimage import DummyImage
 
 _DUMMYIMAGE_RIGHT_CONFIG = {'width': 800, 'height': 600}
 

--- a/python-plugin-example/tests/test_90_examples/test_shipped_config_files.py
+++ b/python-plugin-example/tests/test_90_examples/test_shipped_config_files.py
@@ -2,7 +2,6 @@ from glob import glob
 from os.path import basename, dirname, join
 
 import pytest
-
 from nichtparasoup.testing.configfile import ConfigFileTest
 
 


### PR DESCRIPTION
finally `flake8-isort` got a version-bump for isort.
this allowed to finally bump `isort`.

since `pylint` conflicts with `isort>=5` aaand `pylint`
does not the best job, it was removed.