### PR TITLE
3.0 dev fix req tox

### DIFF
--- a/.github/workflows/test-python-package.yaml
+++ b/.github/workflows/test-python-package.yaml
@@ -121,7 +121,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U wheel setuptools pip
-          python -m pip install tox -c requirements/tox.txt
+          python -m pip install -r requirements/tox.txt
       - name: Test ${{ env.project-directory }}
         id: tests
         run:
@@ -219,7 +219,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U wheel setuptools pip
-          python -m pip install coverage tox -c requirements/tests.txt -c requirements/tox.txt
+          python -m pip install -r requirements/tests.txt -r requirements/tox.txt
       - name: Merge pytest-reports
         run: python -m tox -r -e pytests_merge
       - name: Merge coverage

--- a/.github/workflows/test-python-plugin-example.yaml
+++ b/.github/workflows/test-python-plugin-example.yaml
@@ -192,7 +192,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U wheel setuptools pip
-          python -m pip install coverage tox -c requirements/tests.txt -c requirements/tox.txt
+          python -m pip install -r requirements/tests.txt -r requirements/tox.txt
       - name: Merge pytest-reports
         run: python -m tox -r -e pytests_merge
       - name: Merge pytest-coverage

--- a/python-package/requirements/build.in
+++ b/python-package/requirements/build.in
@@ -2,3 +2,5 @@ pep517
 setuptools
 wheel
 pip
+
+-c constraints.txt

--- a/python-package/requirements/constraints.txt
+++ b/python-package/requirements/constraints.txt
@@ -1,0 +1,14 @@
+# constraints from the package itself:
+# set as `install_requires`
+
+    typing-extensions >= 3.7.4 ; python_version < '3.8'
+    # for ConfigFiles:
+    ruamel.yaml >= 0.16
+    yamale >= 3.0
+    # for WebServer:
+    werkzeug >= 1.0 , < 2.0
+    mako >= 1.1
+    # for PluginsSupport:
+    setuptools >= 41.0
+    # for CLI:
+    click >= 7.1 , < 8.0

--- a/python-package/requirements/dev.in
+++ b/python-package/requirements/dev.in
@@ -1,6 +1,9 @@
 -r style.in
 -r tests.in
 -r tox.in
+
 pip-tools >= 5.3
 isort >= 5.0
 autopep8 >= 1.5
+
+-c constraints.txt

--- a/python-package/requirements/dev.txt
+++ b/python-package/requirements/dev.txt
@@ -13,8 +13,10 @@ attrs==21.2.0
 autopep8==1.5.7
     # via -r requirements/dev.in
 click==7.1.2
-    # via pip-tools
-coverage==5.5
+    # via
+    #   -c requirements/constraints.txt
+    #   pip-tools
+coverage[toml]==5.5
     # via
     #   -r requirements/tests.in
     #   pytest-cov
@@ -84,7 +86,7 @@ pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/tests.in
 pytest-mock==3.6.1
     # via -r requirements/tests.in
@@ -102,6 +104,7 @@ testfixtures==6.17.1
 toml==0.10.2
     # via
     #   autopep8
+    #   coverage
     #   pep517
     #   pytest
     #   tox
@@ -109,7 +112,7 @@ tox==3.23.1
     # via -r requirements/tox.in
 typed-ast==1.4.3
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via mypy
 virtualenv==20.4.6
     # via tox

--- a/python-package/requirements/style.in
+++ b/python-package/requirements/style.in
@@ -11,3 +11,5 @@ pep8-naming >= 0.9
 mypy >= 0.761
 
 # pylint >= 2.5
+
+-c constraints.txt

--- a/python-package/requirements/style.txt
+++ b/python-package/requirements/style.txt
@@ -41,5 +41,5 @@ testfixtures==6.17.1
     # via flake8-isort
 typed-ast==1.4.3
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via mypy

--- a/python-package/requirements/tests.in
+++ b/python-package/requirements/tests.in
@@ -4,3 +4,4 @@ pytest >= 6.0
 pytest-cov >= 2.10
 pytest-mock >= 3.3
 
+-c constraints.txt

--- a/python-package/requirements/tests.txt
+++ b/python-package/requirements/tests.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.2.0
     # via pytest
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/tests.in
     #   pytest-cov
@@ -24,7 +24,7 @@ py==1.10.0
     # via pytest
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/tests.in
 pytest-mock==3.6.1
     # via -r requirements/tests.in
@@ -34,4 +34,6 @@ pytest==6.2.4
     #   pytest-cov
     #   pytest-mock
 toml==0.10.2
-    # via pytest
+    # via
+    #   coverage
+    #   pytest

--- a/python-package/requirements/tox.in
+++ b/python-package/requirements/tox.in
@@ -1,1 +1,3 @@
 tox >= 3.14
+
+-c constraints.txt

--- a/python-package/tox.ini
+++ b/python-package/tox.ini
@@ -22,7 +22,6 @@ download = False
 depends = tests_start
 deps =
     -r requirements/tests.txt
-    -c requirements/dev.txt
 setenv =
     NP_TESTLOG_NAME = {env:NP_TESTLOG_NAME:}_{envname}
 extras =
@@ -37,8 +36,7 @@ commands =
 depends =
 skip_install = True
 deps =
-    coverage
-    -c requirements/dev.txt
+    -r requirements/tests.txt
 setenv =
     NP_TESTLOG_NAME =
 commands =
@@ -51,8 +49,7 @@ depends =
     py{39, 38,37,36}
 skip_install = True
 deps =
-    coverage
-    -c requirements/dev.txt
+    -r requirements/tests.txt
 setenv =
     NP_TESTLOG_NAME =
 commands =
@@ -66,7 +63,6 @@ depends =
 skip_install = True
 deps =
     junitparser
-    -c requirements/dev.txt
 setenv =
     NP_TESTLOG_NAME =
 commands =
@@ -77,9 +73,7 @@ depends =
 skip_install = True
 deps =
     -r requirements/style.txt
-    pytest          # to analyse tests
-    pytest_mock     # to analyse tests
-    -c requirements/dev.txt
+    -r requirements/tests.txt # to analyse tests
 setenv =
     NP_TESTLOG_NAME =
 commands =

--- a/python-plugin-example/requirements/dev.txt
+++ b/python-plugin-example/requirements/dev.txt
@@ -12,9 +12,9 @@ attrs==21.2.0
     #   pytest
 autopep8==1.5.7
     # via -r requirements/dev.in
-click==7.1.2
+click==8.0.1
     # via pip-tools
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/tests.in
     #   pytest-cov
@@ -84,7 +84,7 @@ pyflakes==2.3.1
     # via flake8
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/tests.in
 pytest==6.2.4
     # via
@@ -99,6 +99,7 @@ testfixtures==6.17.1
 toml==0.10.2
     # via
     #   autopep8
+    #   coverage
     #   pep517
     #   pytest
     #   tox
@@ -106,7 +107,7 @@ tox==3.23.1
     # via -r requirements/tox.in
 typed-ast==1.4.3
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via mypy
 virtualenv==20.4.6
     # via tox

--- a/python-plugin-example/requirements/style.txt
+++ b/python-plugin-example/requirements/style.txt
@@ -41,5 +41,5 @@ testfixtures==6.17.1
     # via flake8-isort
 typed-ast==1.4.3
     # via mypy
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.0
     # via mypy

--- a/python-plugin-example/requirements/tests.txt
+++ b/python-plugin-example/requirements/tests.txt
@@ -6,7 +6,7 @@
 #
 attrs==21.2.0
     # via pytest
-coverage==5.5
+coverage[toml]==5.5
     # via
     #   -r requirements/tests.in
     #   pytest-cov
@@ -24,11 +24,13 @@ py==1.10.0
     # via pytest
 pyparsing==2.4.7
     # via packaging
-pytest-cov==2.11.1
+pytest-cov==2.12.0
     # via -r requirements/tests.in
 pytest==6.2.4
     # via
     #   -r requirements/tests.in
     #   pytest-cov
 toml==0.10.2
-    # via pytest
+    # via
+    #   coverage
+    #   pytest

--- a/python-plugin-example/tox.ini
+++ b/python-plugin-example/tox.ini
@@ -22,7 +22,6 @@ download = False
 depends = tests_start
 deps =
     -r requirements/tests.txt
-    -c requirements/dev.txt
 commands =
     # !!! specialties for running in this dev env. Remove them when adopting for a real-world plugin.
     # get the current in-dev version of nichtparasoup
@@ -36,8 +35,7 @@ commands =
 depends =
 skip_install = True
 deps =
-    coverage
-    -c requirements/dev.txt
+    -r requirements/tests.txt
 commands =
     {envpython} -m coverage erase
     {envpython} -c 'import shutil; shutil.rmtree("reports", True);'
@@ -48,8 +46,7 @@ depends =
     py{39,38,37,36}
 skip_install = True
 deps =
-    coverage
-    -c requirements/dev.txt
+    -r requirements/tests.txt
 commands =
     {envpython} -m coverage xml
     {envpython} -m coverage report
@@ -61,7 +58,6 @@ depends =
 skip_install = True
 deps =
     junitparser
-    -c requirements/dev.txt
 commands =
     {envpython} -m junitparser merge --glob reports/pytests/*.xml reports/pytests.xml
 
@@ -70,11 +66,10 @@ depends =
 skip_install = True
 deps =
     -r requirements/style.txt
-    pytest   # to analyse tests
-    -c requirements/dev.txt
+    -r requirements/tests.txt   # to analyse tests
 commands =
     # !!! specialties for running in this dev env. Remove them when adopting for a real-world plugin.
     # get the current in-dev version of nichtparasoup
     {envpython} -m flake8
-    {envpython} -m pip install -q -U {toxinidir}/../python-package  -c requirements/dev.txt
+    {envpython} -m pip install -q -U {toxinidir}/../python-package  # -c requirements/dev.txt
     {envpython} -m mypy


### PR DESCRIPTION
some dependencie bumpes caused issues, since they are not in a format that is usable by pip-constraints:
* #595
* #596
* #601
* #602

also some package constraints were not added to the dev-requirements ... 


these issues were fixed, now.

this topic is kind of an issue.

the requirements that are written are not usable as a constraint file.
maybe i need to have the `pip-tools` fixed ... see https://github.com/jazzband/pip-tools/issues/1300
